### PR TITLE
Avoid sending undefined address value to getERC20Data function

### DIFF
--- a/sections/AelinPool/ViewPool.tsx
+++ b/sections/AelinPool/ViewPool.tsx
@@ -63,7 +63,7 @@ const ViewPool: FC<ViewPoolProps> = ({ pool, poolAddress }) => {
 
 	useEffect(() => {
 		async function getDealInfo() {
-			if (deal?.id != null && provider != null && walletAddress != null) {
+			if (deal?.id != null && deal?.underlyingDealToken && provider != null && walletAddress != null) {
 				const contract = new ethers.Contract(deal?.id, dealAbi, provider);
 				const balance = await contract.balanceOf(walletAddress);
 				const decimals = await contract.decimals();
@@ -75,8 +75,6 @@ const ViewPool: FC<ViewPoolProps> = ({ pool, poolAddress }) => {
 					address: deal?.underlyingDealToken,
 					provider,
 				});
-
-				
 
 				const claimableTokens = Number(
 					ethers.utils.formatUnits(claimable.underlyingClaimable.toString(), underlyingDecimals)


### PR DESCRIPTION
I found the following issue on the pool details page. Sometimes there were a race condition issue and the address to call getERC20Data function was undefined.

<img width="762" alt="Screen Shot 2021-12-17 at 19 06 57" src="https://user-images.githubusercontent.com/15804684/146613736-4c39eaa7-8513-4c54-a854-3ad347c0213e.png">

